### PR TITLE
normalize beam window functions before running anafast

### DIFF
--- a/xbmodeling/gen_model.py
+++ b/xbmodeling/gen_model.py
@@ -189,10 +189,15 @@ def convolve_maps(maps, doconv=True):
         Returns maps data with extra "convmap[T,Q,U]" maps.
     """
 
+    # Get pairsum and pairdiff beams, find and normalize their window functions
     pairsum = (maps["beammapA"] + maps["beammapB"]).values
     pairsum /= np.sum(pairsum)
+    pairsum_windowfunc = hp.anafast(pairsum)
+    pairsum_windowfunc /= pairsum_windowfunc[0]
     pairdiff = (maps["beammapA"] + maps["beammapB"]).values
     pairdiff /= np.sum(pairdiff)
+    pairdiff_windowfunc = hp.anafast(pairdiff)
+    pairdiff_windowfunc /= pairdiff_windowfunc[0]
 
     # Suppress healpy output
     with suppress_stdout():
@@ -200,18 +205,18 @@ def convolve_maps(maps, doconv=True):
             # Temperature map has both CMB and ground
             maps["convmapT"] = hp.smoothing(
                 (maps["cmbmapT"] + maps["groundmap"]).values,
-                beam_window=hp.anafast(pairdiff)
+                beam_window=pairdiff_windowfunc
             )
 
             # Polarization maps only have CMB
             maps["convmapQ"] = hp.smoothing(
                 maps["cmbmapQ"].values,
-                beam_window=hp.anafast(pairsum)
+                beam_window=pairsum_windowfunc
             )
 
             maps["convmapU"] = hp.smoothing(
                 maps["cmbmapU"].values,
-                beam_window=hp.anafast(pairsum)
+                beam_window=pairsum_windowfunc
             )
 
         else:


### PR DESCRIPTION
This ensures the convolved T/Q/U maps are appropriately scaled in amplitude.

Can double-check by observing with a near delta function beam and comparing the standard and convolved Q maps.
```
a = [1, 0, 0, 0.1, 0.1, 0.5]  
b = [0, 0, 0, 10, 10, 0]
model.observe(mainA=a,mainB=a,extended=b)   
 hp.mollview(model.maps['cmbmapQ'], min=-1e-5, max=1e-5,title='CMB Map Q')    
 hp.mollview(model.maps['convmapQ'], min=-1e-5, max=1e-5,title='CMB Conv Q') 
```
(could also use `mapplot` but the above will fix the cscale).     